### PR TITLE
networker::service depends on a non-existant file

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,4 +16,12 @@ class networker::install (
     }
 
   } # end case
+
+  exec { 'create_nsr':
+    command   => 'nsrexecd && pkill nsrexecd',
+    path      => '/usr/bin:/usr/sbin',
+    unless    => 'test -e /nsr/res/servers',
+    creates   => '/nsr/res/servers'
+  }
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,10 +18,11 @@ class networker::install (
   } # end case
 
   exec { 'create_nsr':
-    command   => 'nsrexecd && pkill nsrexecd',
-    path      => '/usr/bin:/usr/sbin',
-    unless    => 'test -e /nsr/res/servers',
-    creates   => '/nsr/res/servers'
+    command => 'nsrexecd && pkill nsrexecd',
+    path    => '/usr/bin:/usr/sbin',
+    unless  => 'test -e /nsr/res/servers',
+    creates => '/nsr/res/servers',
+    require => Package[$packages]
   }
 
 }


### PR DESCRIPTION
The directory /nsr does not exist on a new install of lgtoclnt. This exec creates it if it does not exist, allowing the service to start on first run.

Info: Applying configuration version '1426082371'
Notice: /Stage[main]/Networker::Install/Package[lgtoclnt]/ensure: created
Notice: /Stage[main]/Networker::Install/Package[lgtoman]/ensure: created
Notice: /Stage[main]/Networker::Install/Exec[create_nsr]/returns: executed successfully
Notice: /Stage[main]/Networker::Config/File[/nsr/res/servers]/ensure: created
Info: /Stage[main]/Networker::Config/File[/nsr/res/servers]: Scheduling refresh of Service[networker]
Notice: /Stage[main]/Networker::Service/Service[networker]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Networker::Service/Service[networker]: Unscheduling refresh on Service[networker]
